### PR TITLE
feat: Impl ROM Read

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,14 +1,11 @@
 package main
 
 import (
-	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"n64emu/pkg/core"
-	"n64emu/pkg/util"
+	"n64emu/pkg/core/rom"
 	"os"
-	"path/filepath"
 )
 
 var (
@@ -38,13 +35,16 @@ func Run() int {
 	}
 
 	path := flag.Arg(0)
-	_, err := readROM(path)
+	r, err := rom.NewRom(path)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to read ROM data: %s\n", err)
 		return exitCodeError
 	}
 
+	// test code
+	fmt.Printf("ROM ImageName='%s'\n", r.ImageName)
 	core.Hello()
+
 	return exitCodeOK
 }
 
@@ -53,21 +53,4 @@ func getVersion() string {
 		return "Develop"
 	}
 	return version
-}
-
-func readROM(path string) ([]byte, error) {
-	if path == "" {
-		return []byte{}, errors.New("please enter ROM file path")
-	}
-
-	extFilter := []string{".z64", ".n64"}
-	if !util.Contains(extFilter, filepath.Ext(path)) {
-		return []byte{}, fmt.Errorf("please enter file which has the following extension: %v", extFilter)
-	}
-
-	bytes, err := ioutil.ReadFile(path)
-	if err != nil {
-		return []byte{}, errors.New("fail to read file")
-	}
-	return bytes, nil
 }

--- a/pkg/core/rom/rom.go
+++ b/pkg/core/rom/rom.go
@@ -1,0 +1,89 @@
+/*
+.N64 .Z64 ROM Reader
+*/
+
+package rom
+
+import (
+	"errors"
+)
+
+const (
+	// (Native) .N64, z64
+	RomHeaderBigEndian = 0x80371240
+	// .rom, .u64, .v64
+	RomHeaderBigEndianByteSwapped = 0x37804012
+	// .n64
+	RomHeaderLittleEndian            = 0x40123780
+	RomHeaderLittleEndianByteSwapped = 0x12408037
+)
+
+type Rom struct {
+}
+
+// Swap the values of A and B.
+func swap(a *byte, b *byte) {
+	tmp := *a
+	*a = *b
+	*b = tmp
+}
+
+// Restore a byte-swapped array
+func convertByteSwapped(src *[]byte) error {
+	if len(*src)%2 != 0 {
+		return errors.New("ROM size not divisible by two")
+	}
+
+	loopCount := len(*src) / 2
+	for i := 0; i < loopCount; i++ {
+		index := i * 2
+		swap(*src[index], *src[index+1])
+	}
+}
+
+// Convert little-endian arrays to big-endian arrays
+func convertLittle(src *[]byte) error {
+	if len(*src)%4 != 0 {
+		return errors.New("ROM size not divisible by four")
+	}
+
+	loopCount := len(*src) / 4
+	for i := 0; i < loopCount; i++ {
+		index := i * 4
+		swap(*src[index], *src[index+3])
+		swap(*src[index+1], *src[index+2])
+	}
+}
+
+// Repairing array order
+func repairOrder(src *[]byte) error {
+	if len(*src) < 4 {
+		return errors.New("The size is less than 4 bytes")
+	}
+
+	header := (uint32(*src[0]) << 24) | (uint32(*src[1]) << 16) | (uint32(*src[2]) << 8) | (uint32(*src[3]) << 0)
+	switch header {
+	case RomHeaderBigEndian:
+		break
+	case RomHeaderBigEndianByteSwapped:
+		if err := convertByteSwapped(src); err != nil {
+			return err
+		}
+		break
+	case RomHeaderLittleEndian:
+		if err := convertLittle(src); err != nil {
+			return err
+		}
+		break
+	case RomHeaderLittleEndianByteSwapped:
+		if err := convertLittle(src); err != nil {
+			return err
+		}
+		if err := convertByteSwapped(src); err != nil {
+			return err
+		}
+		break
+	default:
+		return errors.New("Invalid Header")
+	}
+}

--- a/pkg/core/rom/rom.go
+++ b/pkg/core/rom/rom.go
@@ -126,43 +126,43 @@ func swap(a *byte, b *byte) {
 }
 
 // Restore a byte-swapped array
-func convertByteSwapped(src *[]byte) error {
-	if len(*src)%2 != 0 {
+func convertByteSwapped(src []byte) error {
+	if len(src)%2 != 0 {
 		return errors.New("ROM size not divisible by two")
 	}
 
-	loopCount := len(*src) / 2
+	loopCount := len(src) / 2
 	for i := 0; i < loopCount; i++ {
 		index := i * 2
-		swap(&(*src)[index], &(*src)[index+1])
+		swap(&src[index], &src[index+1])
 	}
 
 	return nil
 }
 
 // Convert little-endian arrays to big-endian arrays
-func convertLittle(src *[]byte) error {
-	if len(*src)%4 != 0 {
+func convertLittle(src []byte) error {
+	if len(src)%4 != 0 {
 		return errors.New("ROM size not divisible by four")
 	}
 
-	loopCount := len(*src) / 4
+	loopCount := len(src) / 4
 	for i := 0; i < loopCount; i++ {
 		index := i * 4
-		swap(&(*src)[index], &(*src)[index+3])
-		swap(&(*src)[index+1], &(*src)[index+2])
+		swap(&src[index], &src[index+3])
+		swap(&src[index+1], &src[index+2])
 	}
 
 	return nil
 }
 
 // Repairing array order
-func repairOrder(src *[]byte) error {
-	if len(*src) < 4 {
+func repairOrder(src []byte) error {
+	if len(src) < 4 {
 		return errors.New("The size is less than 4 bytes")
 	}
 
-	header := (uint32((*src)[0]) << 24) | (uint32((*src)[1]) << 16) | (uint32((*src)[2]) << 8) | (uint32((*src)[3]) << 0)
+	header := (uint32(src[0]) << 24) | (uint32(src[1]) << 16) | (uint32(src[2]) << 8) | (uint32(src[3]) << 0)
 	switch header {
 	case RomHeaderBigEndian:
 		break
@@ -224,7 +224,7 @@ func NewRom(romPath string) (Rom, error) {
 	}
 
 	// Detect identifier. repair rom endian and byte-swapped.
-	if err := repairOrder(&src); err != nil {
+	if err := repairOrder(src); err != nil {
 		return dst, err
 	}
 

--- a/pkg/core/rom/rom.go
+++ b/pkg/core/rom/rom.go
@@ -28,6 +28,7 @@ Cartridge ROM Header format:
 package rom
 
 import (
+	"encoding/binary"
 	"errors"
 	"io/ioutil"
 	"n64emu/pkg/types"
@@ -232,14 +233,14 @@ func NewRom(romPath string) (Rom, error) {
 	}
 
 	// Parse cartridge rom header and data
-	dst.ClockRateOverride = (types.Word(src[0x04]) << 24) | (types.Word(src[0x05]) << 16) | (types.Word(src[0x06]) << 8) | (types.Word(src[0x07]) << 0)
-	dst.ProgramCounter = (types.Word(src[0x08]) << 24) | (types.Word(src[0x09]) << 16) | (types.Word(src[0x0a]) << 8) | (types.Word(src[0x0b]) << 0)
-	dst.ReleaseAddress = (types.Word(src[0x0c]) << 24) | (types.Word(src[0x0d]) << 16) | (types.Word(src[0x0e]) << 8) | (types.Word(src[0x0f]) << 0)
-	dst.Crc1 = (types.Word(src[0x10]) << 24) | (types.Word(src[0x11]) << 16) | (types.Word(src[0x12]) << 8) | (types.Word(src[0x13]) << 0)
-	dst.Crc2 = (types.Word(src[0x14]) << 24) | (types.Word(src[0x15]) << 16) | (types.Word(src[0x16]) << 8) | (types.Word(src[0x17]) << 0)
+	dst.ClockRateOverride = types.Word(binary.BigEndian.Uint32(byteArr[0x4:0x8]))
+	dst.ProgramCounter = types.Word(binary.BigEndian.Uint32(byteArr[0x8:0xc]))
+	dst.ReleaseAddress = types.Word(binary.BigEndian.Uint32(byteArr[0xc:0x10]))
+	dst.Crc1 = types.Word(binary.BigEndian.Uint32(byteArr[0x10:0x14]))
+	dst.Crc2 = types.Word(binary.BigEndian.Uint32(byteArr[0x14:0x18]))
 	dst.ImageName = string(byteArr[0x20 : 0x20+ImageNameSize]) // 0x20 ~ 0x34
-	dst.MediaFormat = (types.Word(src[0x38]) << 24) | (types.Word(src[0x39]) << 16) | (types.Word(src[0x3a]) << 8) | (types.Word(src[0x3b]) << 0)
-	dst.CartridgeId = (types.HalfWord(src[0x3c]) << 8) | (types.HalfWord(src[0x3d]) << 0)
+	dst.MediaFormat = types.Word(binary.BigEndian.Uint32(byteArr[0x38:0x3c]))
+	dst.CartridgeId = types.HalfWord(binary.BigEndian.Uint16(byteArr[0x3c:0x3e]))
 	dst.CountryCode = CountryCode(src[0x3e])
 	dst.Version = types.Byte(src[0x3f])
 	dst.BootCode = src[0x40 : 0x40+BootCodeSize] // 0x40 ~ 0x1000

--- a/pkg/core/rom/rom.go
+++ b/pkg/core/rom/rom.go
@@ -1,5 +1,5 @@
 /*
-.N64 .Z64 ROM Reader
+ROM Reader
 http://en64.shoutwiki.com/wiki/ROM#Cartridge_ROM_Header
 
 Cartridge ROM Header format:

--- a/pkg/core/rom/rom_test.go
+++ b/pkg/core/rom/rom_test.go
@@ -2,6 +2,7 @@ package rom
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -37,10 +38,10 @@ func TestReadRom(t *testing.T) {
 	}
 
 	// check conversion process
-	assert.Equal(t, uint32(RomHeaderBigEndian), (uint32(bigEndianSrc[0])<<24)|(uint32(bigEndianSrc[1])<<16)|(uint32(bigEndianSrc[2])<<8)|(uint32(bigEndianSrc[3])<<0))
-	assert.Equal(t, uint32(RomHeaderBigEndianByteSwapped), (uint32(bigEndianByteSwapSrc[0])<<24)|(uint32(bigEndianByteSwapSrc[1])<<16)|(uint32(bigEndianByteSwapSrc[2])<<8)|(uint32(bigEndianByteSwapSrc[3])<<0))
-	assert.Equal(t, uint32(RomHeaderLittleEndian), (uint32(littleEndianSrc[0])<<24)|(uint32(littleEndianSrc[1])<<16)|(uint32(littleEndianSrc[2])<<8)|(uint32(littleEndianSrc[3])<<0))
-	assert.Equal(t, uint32(RomHeaderLittleEndianByteSwapped), (uint32(littleEndianByteSwapSrc[0])<<24)|(uint32(littleEndianByteSwapSrc[1])<<16)|(uint32(littleEndianByteSwapSrc[2])<<8)|(uint32(littleEndianByteSwapSrc[3])<<0))
+	assert.Equal(t, uint32(RomHeaderBigEndian), binary.BigEndian.Uint32(bigEndianSrc[:4]))
+	assert.Equal(t, uint32(RomHeaderBigEndianByteSwapped), binary.BigEndian.Uint32(bigEndianByteSwapSrc[:4]))
+	assert.Equal(t, uint32(RomHeaderLittleEndian), binary.BigEndian.Uint32(littleEndianSrc[:4]))
+	assert.Equal(t, uint32(RomHeaderLittleEndianByteSwapped), binary.BigEndian.Uint32(littleEndianByteSwapSrc[:4]))
 
 	// setup tests
 	want := "ofuton-dev/n64dev   "

--- a/pkg/core/rom/rom_test.go
+++ b/pkg/core/rom/rom_test.go
@@ -1,0 +1,74 @@
+package rom
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReadRom(t *testing.T) {
+	// big-endian, no byteswap
+	header := []byte{
+		0x80, 0x37, 0x12, 0x40, 0x00, 0x00, 0x00, 0x0F, 0x80, 0x00, 0x10, 0x00, 0x00, 0x00, 0x14, 0x44,
+		0xB5, 0xAF, 0x61, 0xE1, 0xB7, 0xEF, 0x19, 0xE2, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x6f, 0x66, 0x75, 0x74, 0x6f, 0x6e, 0x2d, 0x64, 0x65, 0x76, 0x2f, 0x6e, 0x36, 0x34, 0x64, 0x65, // "ofuton-dev/n64dev   "
+		0x76, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00,
+	}
+	// dummy data
+	bootCode := bytes.Repeat([]byte{0x0}, BootCodeSize)
+	// 0, 1, 2, 3, 4, 5, 6, 7, ...
+	bigEndianSrc := append(header, bootCode...)
+
+	// create other order array
+	bigEndianByteSwapSrc := make([]byte, RomHeaderSize)
+	littleEndianSrc := make([]byte, RomHeaderSize)
+	littleEndianByteSwapSrc := make([]byte, RomHeaderSize)
+	for i := 0; i < len(bigEndianSrc); i++ {
+		// 1, 0, 3, 2, 5, 4, 7, 6, ...
+		bigEndianByteSwapSrc[i] = bigEndianSrc[i^0x1]
+		// 3, 2, 1, 0, 7, 6, 5, 4, ...
+		littleEndianSrc[i] = bigEndianSrc[(i & ^0x3)|(3-(i%4))]
+		// 2, 3, 0, 1, 6, 7, 4, 5, ...
+		littleEndianByteSwapSrc[i] = bigEndianSrc[(i & ^0x3)|(3-(i%4))^0x1]
+	}
+
+	// check conversion process
+	assert.Equal(t, uint32(RomHeaderBigEndian), (uint32(bigEndianSrc[0])<<24)|(uint32(bigEndianSrc[1])<<16)|(uint32(bigEndianSrc[2])<<8)|(uint32(bigEndianSrc[3])<<0))
+	assert.Equal(t, uint32(RomHeaderBigEndianByteSwapped), (uint32(bigEndianByteSwapSrc[0])<<24)|(uint32(bigEndianByteSwapSrc[1])<<16)|(uint32(bigEndianByteSwapSrc[2])<<8)|(uint32(bigEndianByteSwapSrc[3])<<0))
+	assert.Equal(t, uint32(RomHeaderLittleEndian), (uint32(littleEndianSrc[0])<<24)|(uint32(littleEndianSrc[1])<<16)|(uint32(littleEndianSrc[2])<<8)|(uint32(littleEndianSrc[3])<<0))
+	assert.Equal(t, uint32(RomHeaderLittleEndianByteSwapped), (uint32(littleEndianByteSwapSrc[0])<<24)|(uint32(littleEndianByteSwapSrc[1])<<16)|(uint32(littleEndianByteSwapSrc[2])<<8)|(uint32(littleEndianByteSwapSrc[3])<<0))
+
+	// setup tests
+	want := "ofuton-dev/n64dev   "
+	tests := []struct {
+		name string
+		src  []byte
+	}{
+		{name: "BigEndian", src: bigEndianSrc},
+		{name: "BigEndianByteSwap", src: bigEndianByteSwapSrc},
+		{name: "LittleEndian", src: littleEndianSrc},
+		{name: "LittleEndianByteSwap", src: littleEndianByteSwapSrc},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dummyFile := fmt.Sprintf("%s.tmp", tt.name)
+
+			// write dummy file
+			ioutil.WriteFile(dummyFile, tt.src, 0644)
+			defer os.Remove(dummyFile)
+
+			// read rom
+			rom, err := NewRom(dummyFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// check read data
+			assert.Equal(t, want, rom.ImageName)
+		})
+	}
+}


### PR DESCRIPTION
.n64, .z64, .v64 fileを読み込んでHeaderを展開する実装を入れました。
どうやらendian, byteswapが形式によってバラバラのようですが [Reddit](https://www.reddit.com/r/emulation/comments/7hrvzp/the_three_different_n64_rom_formats_explained_for/?st=jn9t30t4&sh=1951de19) を参考に変換する機能を実装しているので対応できるはずです。

入れてない実装は以下です
* Bus Masterから展開されたデータを読み出す機能
  * 私もMemoryMapまわりを把握できていないのでこのリサーチと、Bus I/F周りが落ち着くまで後回し
* CRC検査
  * ひとまず後回し。Boot Process上必須なら優先して実装する必要がありそうです

main.goからも指定できるようにしておきました
```
$ go run ./cmd/ ./CPUADD.N64 
ROM ImageName='CPU TEST CPU ADD    '
Hello n64emu!
```