### PR TITLE
Impl some instrs

### DIFF
--- a/pkg/core/mips/r4300i/cpu/alu.go
+++ b/pkg/core/mips/r4300i/cpu/alu.go
@@ -117,8 +117,39 @@ func mtlo(gpr *reg.GPR, inst *InstR) *aluOutput {
 	}
 }
 
+// DSLLV rd, rt, rs
+// Shifts the contents of register rt to the left, and inserts 0 to the low-order bits.
+func dsllv(gpr *reg.GPR, inst *InstR) *aluOutput {
+	return &aluOutput{
+		destType:     destTypeGPR,
+		destGPRIndex: inst.Rd,
+		result:       types.DoubleWord((gpr.Read(inst.Rt)) << (inst.Rs & 0x3F)),
+	}
+}
+
+// DSRLV rd, rt, rs
+// Shifts the contents of register rt to the right, and inserts 0 to the higher bits.
+func dsrlv(gpr *reg.GPR, inst *InstR) *aluOutput {
+	return &aluOutput{
+		destType:     destTypeGPR,
+		destGPRIndex: inst.Rd,
+		result:       types.DoubleWord((gpr.Read(inst.Rt)) >> (inst.Rs & 0x3F)),
+	}
+}
+
+// DSRAV rd, rt, rs
+// Shifts the contents of register rt to the right, and sign-extends the high-order bits.
+func dsrav(gpr *reg.GPR, inst *InstR) *aluOutput {
+	return &aluOutput{
+		destType:     destTypeGPR,
+		destGPRIndex: inst.Rd,
+		result:       types.DoubleWord(int64(gpr.Read(inst.Rt)) >> (inst.Rs & 0x3F)),
+	}
+}
+
 func or(gpr *reg.GPR, inst *InstR) *aluOutput {
 	return &aluOutput{
+		destType:     destTypeGPR,
 		destGPRIndex: inst.Rd,
 		result:       types.DoubleWord(gpr.Read(inst.Rs) | gpr.Read(inst.Rt)),
 	}

--- a/pkg/core/mips/r4300i/cpu/alu.go
+++ b/pkg/core/mips/r4300i/cpu/alu.go
@@ -5,17 +5,27 @@ import (
 	"n64emu/pkg/types"
 )
 
+type destType byte
+
+const (
+	destTypeGPR destType = iota
+	destTypeHi
+	destTypeLo
+)
+
 type aluOutput struct {
-	dest   types.Byte
-	result types.DoubleWord
+	destType     destType
+	destGPRIndex types.Byte
+	result       types.DoubleWord
 }
 
 // SLL rd, rt, sa
 // The contents of general purpose register rt are shifted left by sa bits, inserting zeros into the low-order bits.
 func sll(gpr *reg.GPR, inst *InstR) *aluOutput {
 	return &aluOutput{
-		dest:   inst.Rd,
-		result: types.DoubleWord((int32(gpr.Read(inst.Rt)) << inst.Sa)),
+		destType:     destTypeGPR,
+		destGPRIndex: inst.Rd,
+		result:       types.DoubleWord((int32(gpr.Read(inst.Rt)) << inst.Sa)),
 	}
 }
 
@@ -23,8 +33,9 @@ func sll(gpr *reg.GPR, inst *InstR) *aluOutput {
 // The contents of general purpose register rt are shifted right by sa bits, inserting zeros into the high-order bits.
 func srl(gpr *reg.GPR, inst *InstR) *aluOutput {
 	return &aluOutput{
-		dest:   inst.Rd,
-		result: types.DoubleWord((gpr.Read(inst.Rt)) >> inst.Sa),
+		destType:     destTypeGPR,
+		destGPRIndex: inst.Rd,
+		result:       types.DoubleWord((gpr.Read(inst.Rt)) >> inst.Sa),
 	}
 }
 
@@ -32,8 +43,9 @@ func srl(gpr *reg.GPR, inst *InstR) *aluOutput {
 // Shifts the contents of register rt sa bits to the right, and sign-extends the high- order bits.
 func sra(gpr *reg.GPR, inst *InstR) *aluOutput {
 	return &aluOutput{
-		dest:   inst.Rd,
-		result: types.DoubleWord(int32(gpr.Read(inst.Rt)) >> inst.Sa),
+		destType:     destTypeGPR,
+		destGPRIndex: inst.Rd,
+		result:       types.DoubleWord(int32(gpr.Read(inst.Rt)) >> inst.Sa),
 	}
 }
 
@@ -41,8 +53,9 @@ func sra(gpr *reg.GPR, inst *InstR) *aluOutput {
 // Shifts the contents of register rt to the left and inserts 0 to the low-order bits.
 func sllv(gpr *reg.GPR, inst *InstR) *aluOutput {
 	return &aluOutput{
-		dest:   inst.Rd,
-		result: types.DoubleWord(int32(gpr.Read(inst.Rt)) << (inst.Rs & 0x1F)),
+		destType:     destTypeGPR,
+		destGPRIndex: inst.Rd,
+		result:       types.DoubleWord(int32(gpr.Read(inst.Rt)) << (inst.Rs & 0x1F)),
 	}
 }
 
@@ -50,8 +63,9 @@ func sllv(gpr *reg.GPR, inst *InstR) *aluOutput {
 // Shifts the contents of register rt to the right, and inserts 0 to the high-order bits.
 func srlv(gpr *reg.GPR, inst *InstR) *aluOutput {
 	return &aluOutput{
-		dest:   inst.Rd,
-		result: types.DoubleWord(int32(gpr.Read(inst.Rt)) >> (inst.Rs & 0x1F)),
+		destType:     destTypeGPR,
+		destGPRIndex: inst.Rd,
+		result:       types.DoubleWord(int32(gpr.Read(inst.Rt)) >> (inst.Rs & 0x1F)),
 	}
 }
 
@@ -59,14 +73,53 @@ func srlv(gpr *reg.GPR, inst *InstR) *aluOutput {
 // Shifts the contents of register rt to the right and sign-extends the high-order bits.
 func srav(gpr *reg.GPR, inst *InstR) *aluOutput {
 	return &aluOutput{
-		dest:   inst.Rd,
-		result: types.DoubleWord(int32(gpr.Read(inst.Rt)) >> (inst.Rs & 0x1F)),
+		destType:     destTypeGPR,
+		destGPRIndex: inst.Rd,
+		result:       types.DoubleWord(int32(gpr.Read(inst.Rt)) >> (inst.Rs & 0x1F)),
+	}
+}
+
+// MFHI rd
+// Transfers the contents of special register HI to register rd.
+func mfhi(hi types.DoubleWord, inst *InstR) *aluOutput {
+	return &aluOutput{
+		destType:     destTypeGPR,
+		destGPRIndex: inst.Rd,
+		result:       hi,
+	}
+}
+
+// MFLO rd
+// Transfers the contents of special register LO to register rd.
+func mflo(lo types.DoubleWord, inst *InstR) *aluOutput {
+	return &aluOutput{
+		destType:     destTypeGPR,
+		destGPRIndex: inst.Rd,
+		result:       lo,
+	}
+}
+
+// MTHI rs
+// Transfers the contents of register rs to special register HI.
+func mthi(gpr *reg.GPR, inst *InstR) *aluOutput {
+	return &aluOutput{
+		destType: destTypeHi,
+		result:   types.DoubleWord(gpr.Read(inst.Rs)),
+	}
+}
+
+// MTLO rs
+// Transfers the contents of register rs to special register LO.
+func mtlo(gpr *reg.GPR, inst *InstR) *aluOutput {
+	return &aluOutput{
+		destType: destTypeLo,
+		result:   types.DoubleWord(gpr.Read(inst.Rs)),
 	}
 }
 
 func or(gpr *reg.GPR, inst *InstR) *aluOutput {
 	return &aluOutput{
-		dest:   inst.Rd,
-		result: types.DoubleWord(gpr.Read(inst.Rs) | gpr.Read(inst.Rt)),
+		destGPRIndex: inst.Rd,
+		result:       types.DoubleWord(gpr.Read(inst.Rs) | gpr.Read(inst.Rt)),
 	}
 }

--- a/pkg/core/mips/r4300i/cpu/alu.go
+++ b/pkg/core/mips/r4300i/cpu/alu.go
@@ -1,6 +1,7 @@
 package cpu
 
 import (
+	"fmt"
 	"n64emu/pkg/core/mips/r4300i/reg"
 	"n64emu/pkg/types"
 )
@@ -120,6 +121,8 @@ func mtlo(gpr *reg.GPR, inst *InstR) *aluOutput {
 // DSLLV rd, rt, rs
 // Shifts the contents of register rt to the left, and inserts 0 to the low-order bits.
 func dsllv(gpr *reg.GPR, inst *InstR) *aluOutput {
+	fmt.Println(gpr, inst.Rs, inst.Rd, inst.Rt)
+
 	return &aluOutput{
 		destType:     destTypeGPR,
 		destGPRIndex: inst.Rd,

--- a/pkg/core/mips/r4300i/cpu/alu.go
+++ b/pkg/core/mips/r4300i/cpu/alu.go
@@ -130,6 +130,9 @@ func dsrav(gpr *reg.GPR, inst *InstR) *aluOutput {
 func mult(gpr *reg.GPR, hi *types.DoubleWord, lo *types.DoubleWord, inst *InstR) *aluOutput {
 	result := types.DoubleWord(int64(gpr.Read(inst.Rt)) * int64(gpr.Read(inst.Rs)))
 	// TODO: We need to do some investigation about write back timing
+	// .     Should we add 20 cycle delay for 64bit mode?
+	//       ref. https://en.wikipedia.org/wiki/R4000#Integer_execution
+	// .     See also, https://github.com/ofuton-dev/n64emu/pull/18
 	*hi = result >> 32
 	*lo = result & 0xFFFFFFFF
 	return nil

--- a/pkg/core/mips/r4300i/cpu/cpu.go
+++ b/pkg/core/mips/r4300i/cpu/cpu.go
@@ -53,7 +53,7 @@ func (c *CPU) fetch() types.Word {
 func (c *CPU) Step() {
 	// TODO: We need to consider about `pipline`.
 	//       Implement later here.
-	c.pipeline.step(c.execute, c.fetch, c.writeBack)
+	c.pipeline.step(&c.gpr, c.execute, c.fetch)
 }
 
 // RunUntil runs CPU until specified cycles
@@ -61,17 +61,6 @@ func (c *CPU) RunUntil(cycle types.Word) {
 	for cycle > 0 {
 		c.Step()
 		cycle--
-	}
-}
-
-func (c *CPU) writeBack(output *aluOutput) {
-	switch output.destType {
-	case destTypeGPR:
-		c.gpr.Write(output.destGPRIndex, output.result)
-	case destTypeHi:
-		c.hi = output.result
-	case destTypeLo:
-		c.lo = output.result
 	}
 }
 
@@ -106,19 +95,19 @@ func (c *CPU) execute(opcode types.Word) *aluOutput {
 		case 0x10: /// MFHI
 			return mfhi(c.hi, &instR)
 		case 0x11: // MTHI
-			return mthi(&c.gpr, &instR)
+			return mthi(&c.gpr, &c.hi, &instR)
 		case 0x12: // MFLO
 			return mflo(c.lo, &instR)
 		case 0x13: // MTLO
-			return mtlo(&c.gpr, &instR)
+			return mtlo(&c.gpr, &c.lo, &instR)
 		case 0x14: // DSLLV
 			return dsllv(&c.gpr, &instR)
 		case 0x16: // DSRLV
 			return dsrlv(&c.gpr, &instR)
 		case 0x17: // DSRAV
 			return dsrav(&c.gpr, &instR)
-		case 0x18:
-			util.TODO("MULT")
+		case 0x18: // MULT
+			return mult(&c.gpr, &c.hi, &c.lo, &instR)
 		case 0x19:
 			util.TODO("MULTU")
 		case 0x1A:

--- a/pkg/core/mips/r4300i/cpu/cpu.go
+++ b/pkg/core/mips/r4300i/cpu/cpu.go
@@ -113,12 +113,12 @@ func (c *CPU) execute(opcode types.Word) *aluOutput {
 			return mflo(c.lo, &instR)
 		case 0x13: // MTLO
 			return mtlo(&c.gpr, &instR)
-		case 0x14:
-			util.TODO("DSLLV")
-		case 0x16:
-			util.TODO("DSRLV")
-		case 0x17:
-			util.TODO("DSRAV")
+		case 0x14: // DSLLV
+			return dsllv(&c.gpr, &instR)
+		case 0x16: // DSRLV
+			return dsrlv(&c.gpr, &instR)
+		case 0x17: // DSRAV
+			return dsrav(&c.gpr, &instR)
 		case 0x18:
 			util.TODO("MULT")
 		case 0x19:

--- a/pkg/core/mips/r4300i/cpu/cpu.go
+++ b/pkg/core/mips/r4300i/cpu/cpu.go
@@ -1,7 +1,6 @@
 package cpu
 
 import (
-	"fmt"
 	"n64emu/pkg/core/bus"
 	"n64emu/pkg/core/mips/r4300i/reg"
 	"n64emu/pkg/types"
@@ -78,7 +77,6 @@ func (c *CPU) writeBack(output *aluOutput) {
 
 func (c *CPU) execute(opcode types.Word) *aluOutput {
 	op := GetOp(opcode)
-	fmt.Println(op)
 	switch op {
 	// R type instructions
 	// SPECIAL

--- a/pkg/core/mips/r4300i/cpu/cpu_test.go
+++ b/pkg/core/mips/r4300i/cpu/cpu_test.go
@@ -2,6 +2,7 @@ package cpu
 
 import (
 	"encoding/binary"
+	"fmt"
 	"n64emu/pkg/types"
 	"testing"
 
@@ -34,7 +35,7 @@ func (b *MockBus) ReadHalfWord(e types.Endianness, addr types.Word) types.HalfWo
 
 func (b *MockBus) ReadWord(e types.Endianness, addr types.Word) types.Word {
 	// TODO:  For now, fixed by BIG endian
-	return types.Word(b.MockMemory[addr]) | types.Word(b.MockMemory[addr+1])<<8 | types.Word(b.MockMemory[addr+2])<<16 | types.Word(b.MockMemory[addr+3])<<24
+	return types.Word(b.MockMemory[addr])<<24 | types.Word(b.MockMemory[addr+1])<<16 | types.Word(b.MockMemory[addr+2])<<8 | types.Word(b.MockMemory[addr+3])
 }
 
 func (b *MockBus) ReadDoubleWord(e types.Endianness, addr types.Word) types.DoubleWord {
@@ -50,6 +51,7 @@ func (b *MockBus) SetMemory(offset types.Word, data []types.Byte) {
 func beOpcode2bytes(o types.Word) []types.Byte {
 	bytes := make([]byte, 4)
 	binary.BigEndian.PutUint32(bytes, o)
+	fmt.Println(bytes)
 	return bytes
 }
 
@@ -62,12 +64,12 @@ func setupCPU(offset types.Word, data []types.Byte) (*CPU, *MockBus) {
 func TestSLL(t *testing.T) {
 	assert := assert.New(t)
 	// SLL rd=3, rt=2, sa=3
-	cpu, _ := setupCPU(0, beOpcode2bytes(0xC0180200))
+	cpu, _ := setupCPU(0, beOpcode2bytes(0x000218C0))
 	cpu.gpr.Write(2, 0x2)
 	cpu.RunUntil(5)
 	assert.Equal(types.DoubleWord(0x10), cpu.gpr.Read(3), "should shifted value stored")
 	// SLL rd=3, rt=2, sa=0 with sign extended
-	cpu, _ = setupCPU(0, beOpcode2bytes(0x00180200))
+	cpu, _ = setupCPU(0, beOpcode2bytes(0x00021800))
 	cpu.gpr.Write(2, 0x00000000FFFFFFFF)
 	cpu.RunUntil(5)
 	assert.Equal(types.DoubleWord(0xFFFFFFFFFFFFFFFF), cpu.gpr.Read(3), "should shifted value stored")
@@ -76,7 +78,7 @@ func TestSLL(t *testing.T) {
 func TestSRL(t *testing.T) {
 	assert := assert.New(t)
 	// SLL rd=3, rt=2, sa=3
-	cpu, _ := setupCPU(0, beOpcode2bytes(0xC2180200))
+	cpu, _ := setupCPU(0, beOpcode2bytes(0x000218C2))
 	cpu.gpr.Write(2, 0x10)
 	cpu.RunUntil(5)
 	assert.Equal(types.DoubleWord(0x2), cpu.gpr.Read(3), "should shifted value stored")
@@ -85,16 +87,25 @@ func TestSRL(t *testing.T) {
 func TestSRA(t *testing.T) {
 	assert := assert.New(t)
 	// SLL rd=3, rt=2, sa=3
-	cpu, _ := setupCPU(0, beOpcode2bytes(0xC3180200))
+	cpu, _ := setupCPU(0, beOpcode2bytes(0x000218C3))
 	cpu.gpr.Write(2, 0x00000000FFFFFFFF)
 	cpu.RunUntil(5)
 	assert.Equal(types.DoubleWord(0xFFFFFFFFFFFFFFFF), cpu.gpr.Read(3), "should shifted value stored")
 }
 
+func TestMTHI(t *testing.T) {
+	assert := assert.New(t)
+	// MTHI rs=1
+	cpu, _ := setupCPU(0, beOpcode2bytes(0x00200011))
+	cpu.gpr.Write(1, 0x5555AAAA5555AAAA)
+	cpu.RunUntil(5)
+	assert.Equal(types.DoubleWord(0x5555AAAA5555AAAA), cpu.hi, "should shifted value stored")
+}
+
 func TestOR(t *testing.T) {
 	assert := assert.New(t)
 	// OR rd=3, rs=1, rt=2
-	cpu, _ := setupCPU(0, beOpcode2bytes(0x25182200))
+	cpu, _ := setupCPU(0, beOpcode2bytes(0x00221825))
 	cpu.gpr.Write(1, 0x00000000AAAAAAAA)
 	cpu.gpr.Write(2, 0x5555555500000000)
 	cpu.RunUntil(5)

--- a/pkg/core/mips/r4300i/cpu/pipeline.go
+++ b/pkg/core/mips/r4300i/cpu/pipeline.go
@@ -2,6 +2,7 @@ package cpu
 
 import (
 	"n64emu/pkg/core/bus"
+	"n64emu/pkg/core/mips/r4300i/reg"
 	"n64emu/pkg/types"
 )
 
@@ -21,9 +22,9 @@ func NewPipeline(bus bus.Bus) *Pipeline {
 	}
 }
 
-func (p *Pipeline) step(execute func(types.Word) *aluOutput, fetch func() types.Word, writeBack func(*aluOutput)) {
+func (p *Pipeline) step(gpr *reg.GPR, execute func(types.Word) *aluOutput, fetch func() types.Word) {
 	// TODO: We need to consider about pipeline exception, branch delay, load delay and etc...
-	p.writeBackStage(writeBack)
+	p.writeBackStage(gpr)
 
 	p.dataCacheStage()
 
@@ -35,9 +36,9 @@ func (p *Pipeline) step(execute func(types.Word) *aluOutput, fetch func() types.
 }
 
 // WB - Write Back
-func (p *Pipeline) writeBackStage(writeBack func(*aluOutput)) {
+func (p *Pipeline) writeBackStage(gpr *reg.GPR) {
 	if p.dataCacheLatch != nil {
-		writeBack(p.dataCacheLatch)
+		gpr.Write(p.dataCacheLatch.dest, p.dataCacheLatch.result)
 	}
 }
 

--- a/pkg/core/mips/r4300i/cpu/pipeline.go
+++ b/pkg/core/mips/r4300i/cpu/pipeline.go
@@ -1,13 +1,13 @@
 package cpu
 
 import (
-	"n64emu/pkg/core/mips/r4300i/reg"
+	"n64emu/pkg/core/bus"
 	"n64emu/pkg/types"
-	"n64emu/pkg/util"
 )
 
 // Pipeline is vr4300 pipeline module
 type Pipeline struct {
+	bus                bus.Bus // Bus accessor
 	registerFetchReady bool
 	registerFetchLatch *types.Word
 	executionLatch     *aluOutput
@@ -15,13 +15,15 @@ type Pipeline struct {
 }
 
 // NewPipeline is Pipeline constructor
-func NewPipeline() *Pipeline {
-	return &Pipeline{}
+func NewPipeline(bus bus.Bus) *Pipeline {
+	return &Pipeline{
+		bus: bus,
+	}
 }
 
-func (p *Pipeline) step(gpr *reg.GPR, execute func(opcode types.Word) *aluOutput, fetch func() types.Word) {
+func (p *Pipeline) step(execute func(types.Word) *aluOutput, fetch func() types.Word, writeBack func(*aluOutput)) {
 	// TODO: We need to consider about pipeline exception, branch delay, load delay and etc...
-	p.writeBackStage(gpr)
+	p.writeBackStage(writeBack)
 
 	p.dataCacheStage()
 
@@ -33,9 +35,9 @@ func (p *Pipeline) step(gpr *reg.GPR, execute func(opcode types.Word) *aluOutput
 }
 
 // WB - Write Back
-func (p *Pipeline) writeBackStage(gpr *reg.GPR) {
+func (p *Pipeline) writeBackStage(writeBack func(*aluOutput)) {
 	if p.dataCacheLatch != nil {
-		gpr.Write(p.dataCacheLatch.dest, p.dataCacheLatch.result)
+		writeBack(p.dataCacheLatch)
 	}
 }
 
@@ -45,7 +47,7 @@ func (p *Pipeline) dataCacheStage() {
 }
 
 // EX - Execution
-func (p *Pipeline) executionStage(execute func(opcode types.Word) *aluOutput) {
+func (p *Pipeline) executionStage(execute func(types.Word) *aluOutput) {
 	if p.registerFetchLatch != nil {
 		p.executionLatch = execute(*p.registerFetchLatch)
 	}
@@ -64,251 +66,4 @@ func (p *Pipeline) registerFetchStage(fetch func() types.Word) {
 func (p *Pipeline) instructionCacheFetchStage() {
 	p.registerFetchReady = true
 	// TODO: NOP for now
-}
-
-func (p *Pipeline) execute(gpr *reg.GPR, opcode types.Word) {
-	op := GetOp(opcode)
-	switch op {
-	// R type instructions
-	// SPECIAL
-	case 0x00:
-		instR := DecodeR(opcode)
-		switch instR.Funct {
-		case 0x00: // SLL
-			p.executionLatch = sll(gpr, &instR)
-		case 0x02: // SRL
-			p.executionLatch = srl(gpr, &instR)
-		case 0x03: // SRA
-			p.executionLatch = sra(gpr, &instR)
-		case 0x04:
-			util.TODO("SLLV")
-		case 0x06:
-			util.TODO("SRLL")
-		case 0x07:
-			util.TODO("SRAV")
-		case 0x08:
-			util.TODO("JR")
-		case 0x09:
-			util.TODO("JALR")
-		case 0x0D:
-			util.TODO("BREAK")
-		case 0x0F:
-			util.TODO("SYNC")
-		case 0x10:
-			util.TODO("MFHI")
-		case 0x11:
-			util.TODO("MTHI")
-		case 0x12:
-			util.TODO("MFLO")
-		case 0x13:
-			util.TODO("MTLO")
-		case 0x14:
-			util.TODO("DSLLV")
-		case 0x16:
-			util.TODO("DSRLV")
-		case 0x17:
-			util.TODO("DSRAV")
-		case 0x18:
-			util.TODO("MULT")
-		case 0x19:
-			util.TODO("MULTU")
-		case 0x1A:
-			util.TODO("DIV")
-		case 0x1B:
-			util.TODO("DIVU")
-		case 0x1C:
-			util.TODO("DMULT")
-		case 0x1D:
-			util.TODO("DMULTU")
-		case 0x1E:
-			util.TODO("DDIV")
-		case 0x1F:
-			util.TODO("DDIVU")
-		case 0x20:
-			util.TODO("ADD")
-		case 0x21:
-			util.TODO("ADDU")
-		case 0x22:
-			util.TODO("SUB")
-		case 0x23:
-			util.TODO("SUBU")
-		case 0x24:
-			util.TODO("AND")
-		case 0x25: // OR
-			p.executionLatch = or(gpr, &instR)
-		case 0x26:
-			util.TODO("XOR")
-		case 0x27:
-			util.TODO("NOR")
-		case 0x2A:
-			util.TODO("SLT")
-		case 0x2B:
-			util.TODO("SLTU")
-		case 0x2C:
-			util.TODO("DADD")
-		case 0x2D:
-			util.TODO("DADDU")
-		case 0x2E:
-			util.TODO("DSUB")
-		case 0x2F:
-			util.TODO("DSUBU")
-		case 0x34:
-			util.TODO("TEQ")
-		case 0x38:
-			util.TODO("DSLL")
-		case 0x3A:
-			util.TODO("DSRL")
-		case 0x3B:
-			util.TODO("DSRA")
-		case 0x3C:
-			util.TODO("DSLL32")
-		case 0x3E:
-			util.TODO("DSRL32")
-		case 0x3F:
-			util.TODO("DSRA32")
-		}
-		// TODO: map other instructions
-	case 0x01:
-		instI := DecodeI(opcode)
-		switch instI.Rt {
-		case 0x00:
-			util.TODO("BLTZ")
-		case 0x01:
-			util.TODO("BGEZ")
-		case 0x02:
-			util.TODO("BLTZL")
-		case 0x03:
-			util.TODO("BGEZL")
-		case 0x08:
-			util.TODO("TGEI")
-		case 0x09:
-			util.TODO("TGEIU")
-		case 0x0A:
-			util.TODO("TLTI")
-		case 0x0B:
-			util.TODO("TLTIU")
-		case 0x0C:
-			util.TODO("TEQI")
-		case 0x0E:
-			util.TODO("TNEI")
-		case 0x10:
-			util.TODO("BLTZAL")
-		case 0x11:
-			util.TODO("BGEZAL")
-		case 0x12:
-			util.TODO("BLTZALL")
-		case 0x13:
-			util.TODO("BGEZALL")
-		}
-	case 0x02:
-		util.TODO("J")
-	case 0x03:
-		util.TODO("JAL")
-	case 0x04:
-		util.TODO("BEQ")
-	case 0x05:
-		util.TODO("BNE")
-	case 0x06:
-		util.TODO("BLEZ")
-	case 0x07:
-		util.TODO("BGTZ")
-	case 0x08:
-		util.TODO("ADDI")
-	case 0x09:
-		util.TODO("ADDIU")
-	case 0x0A:
-		util.TODO("SLTI")
-	case 0x0B:
-		util.TODO("SLTIU")
-	case 0x0C:
-		util.TODO("ANDI")
-	case 0x0D:
-		util.TODO("ORI")
-	case 0x0E:
-		util.TODO("XORI")
-	case 0x0F:
-		util.TODO("LUI")
-	case 0x10:
-		util.TODO("COP0")
-	case 0x11:
-		util.TODO("COP1")
-	case 0x12:
-		util.TODO("COP2")
-	case 0x14:
-		util.TODO("BEQL")
-	case 0x15:
-		util.TODO("BNEL")
-	case 0x16:
-		util.TODO("BLEZL")
-	case 0x17:
-		util.TODO("BGTZL")
-	case 0x18:
-		util.TODO("DADDI")
-	case 0x19:
-		util.TODO("DADDIU")
-	case 0x1A:
-		util.TODO("LDL")
-	case 0x1B:
-		util.TODO("LDR")
-	case 0x20:
-		util.TODO("LB")
-	case 0x21:
-		util.TODO("LH")
-	case 0x22:
-		util.TODO("LWL")
-	case 0x23:
-		util.TODO("LW")
-	case 0x24:
-		util.TODO("LBU")
-	case 0x25:
-		util.TODO("LHU")
-	case 0x26:
-		util.TODO("LWR")
-	case 0x27:
-		util.TODO("LWU")
-	case 0x28:
-		util.TODO("SB")
-	case 0x29:
-		util.TODO("SH")
-	case 0x2A:
-		util.TODO("SWL")
-	case 0x2B:
-		util.TODO("SW")
-	case 0x2C:
-		util.TODO("SDL")
-	case 0x2D:
-		util.TODO("SDR")
-	case 0x2E:
-		util.TODO("SWR")
-	case 0x2F:
-		util.TODO("CACHE")
-	case 0x30:
-		util.TODO("LL")
-	case 0x31:
-		util.TODO("LWC1")
-	case 0x32:
-		util.TODO("LWC2")
-	case 0x34:
-		util.TODO("LLD")
-	case 0x35:
-		util.TODO("LDC1")
-	case 0x36:
-		util.TODO("LDC2")
-	case 0x37:
-		util.TODO("LD")
-	case 0x38:
-		util.TODO("SC")
-	case 0x39:
-		util.TODO("SWC1")
-	case 0x3A:
-		util.TODO("SWC2")
-	case 0x3C:
-		util.TODO("SCD")
-	case 0x3D:
-		util.TODO("SDC1")
-	case 0x3E:
-		util.TODO("SDC2")
-	case 0x3F:
-		util.TODO("SD")
-	}
 }


### PR DESCRIPTION
命令を少し足したPRです。
ちまちま命令足してたんですが、よくわからない箇所に遭遇したので意見を聞きたくPRにしました。

> よくわからない箇所

具体的には`MULTなどの乗除算結果がhi/loレジスタに格納されるのはどのタイミングか？`　です。

他の命令同様、EXで演算され、WBで書き戻されるのであれば「`aluOutput`にGPR以外をwriteback先に指定する仕組みがいるなあ」と考えて https://github.com/ofuton-dev/n64emu/pull/18/commits/122bd8022ba0dae705884ab4c883fc6fe09cae95 のように構造を変えたりしてたんですが、ちょっと調べたりしていると本当にWBステージで書き戻されるのかわからなくなっってきました。

例えば以下の資料の `乗除算命令`の箇所を見るとHi/Loレジスタなどはパイプラインから切り離されているように読み取れる気がします。

https://www.cqpub.co.jp/interface/TechI/Vol39/app/mips_asm.pdf

また、Cycle-Accurateをうたっているcen64を見てみても以下のように、よくわかっていないようで、EXステージで書き込んでいるように見えます。

https://github.com/n64dev/cen64/blob/master/vr4300/functions.c#L1258-L1260

https://github.com/n64dev/cen64/blob/master/vr4300/functions.c#L1240-L1241

vr4300のデータシートを読んでみても詳細に言及しているような箇所が見当たらない気がしてどうしたものかという状態で、ひとまずcen64と同じタイミングで扱っておいて、わかり次第対応するのいいですかね...？